### PR TITLE
docs: Fix a few typos

### DIFF
--- a/elevate/modules/UACME/Source/Akagi/methods/hybrids.c
+++ b/elevate/modules/UACME/Source/Akagi/methods/hybrids.c
@@ -377,7 +377,7 @@ BOOL ucmMMCMethod(
         }
 
         //run mmc console
-        //because of mmc harcoded backdoor uac will autoelevate mmc with valid and trusted MS command.
+        //because of mmc hardcoded backdoor uac will autoelevate mmc with valid and trusted MS command.
         //yuubari identified multiple exploits in msc commands loading scheme.
         bResult = supRunProcess(MMC_EXE, lpMscFile);
 

--- a/elevate/modules/UACME/Source/Yuubari/logger.h
+++ b/elevate/modules/UACME/Source/Yuubari/logger.h
@@ -8,7 +8,7 @@
 *
 *  DATE:        13 Feb 2017
 *
-*  Header file for the log file writter.
+*  Header file for the log file writer.
 *
 * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
 * ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED


### PR DESCRIPTION
There are small typos in:
- elevate/modules/UACME/Source/Akagi/methods/hybrids.c
- elevate/modules/UACME/Source/Yuubari/logger.h

Fixes:
- Should read `writer` rather than `writter`.
- Should read `hardcoded` rather than `harcoded`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md